### PR TITLE
remove unneeded diego-specific check

### DIFF
--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -253,9 +253,6 @@ func GuidForAppName(appName string) string {
 func CredhubDescribe(description string, callback func()) bool {
 	return Describe("[credhub]", func() {
 		BeforeEach(func() {
-			if Config.GetBackend() != "diego" {
-				Skip(skip_messages.SkipDiegoMessage)
-			}
 			if !(Config.GetIncludeCredhubAssisted() || Config.GetIncludeCredhubNonAssisted()) {
 				Skip(skip_messages.SkipCredhubMessage)
 			}


### PR DESCRIPTION
Setting credhub_mode to `off` should set this:
https://github.com/HCL-Cloud-Native-Labs/cf-acceptance-tests/blob/master/helpers/config/config_struct.go#L844
and this:
https://github.com/HCL-Cloud-Native-Labs/cf-acceptance-tests/blob/master/helpers/config/config_struct.go#L848
to `false` and will skip credhub tests:
https://github.com/HCL-Cloud-Native-Labs/cf-acceptance-tests/blob/master/cats_suite_helpers/cats_suite_helpers.go#L253
so `diego` check is not needed.