### PR TITLE
Fix hardcoded cflinuxfs3 stacks and output not matching latest cf cli

### DIFF
--- a/apps/admin_buildpack_lifecycle.go
+++ b/apps/admin_buildpack_lifecycle.go
@@ -271,7 +271,7 @@ exit 1
 
 		Expect(push).To(Exit(0))
 		appOutput := cf.Cf("app", appName).Wait()
-		Expect(appOutput).To(Say("buildpacks?:\\s+Simple"))
+		Expect(appOutput).To(Say("buildpacks?:.*\\n.+\\n.*Simple"))
 	}
 
 	itDoesNotDetectForEmptyApp := func() {
@@ -344,7 +344,7 @@ exit 1
 			Expect(cf.Cf("push", appName, "-b", buildpackName, "-m", DEFAULT_MEMORY_LIMIT, "-p", appPath).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 			appOutput := cf.Cf("app", appName).Wait()
-			Expect(appOutput).To(Say("buildpacks?:\\s+" + buildpackName))
+			Expect(appOutput).To(Say("buildpacks?:.*\\n.+\\n.*" + buildpackName))
 		})
 
 		It("fails if the specified buildpack is disabled", func() {

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -222,7 +222,7 @@ func getDefaults() config {
 
 	defaults.NamePrefix = ptrToString("CATS")
 
-	defaults.Stacks = &[]string{"cflinuxfs3"}
+	defaults.Stacks = &[]string{"sle15"}
 	return defaults
 }
 
@@ -656,8 +656,8 @@ func validateStacks(config *config) error {
 	}
 
 	for _, stack := range config.GetStacks() {
-		if stack != "cflinuxfs3" {
-			return fmt.Errorf("* Invalid configuration: unknown stack '%s'. Only 'cflinuxfs3' is supported for the 'stacks' property", stack)
+		if stack != "sle15" {
+			return fmt.Errorf("* Invalid configuration: unknown stack '%s'. Only 'sle15' is supported for the 'stacks' property", stack)
 		}
 	}
 


### PR DESCRIPTION
These are the changes needed in order to get green CATs on kubecf as part of this: https://github.com/cloudfoundry-incubator/kubecf/issues/1007