### PR TITLE
fix comparison

### DIFF
--- a/apps/admin_buildpack_lifecycle.go
+++ b/apps/admin_buildpack_lifecycle.go
@@ -271,7 +271,7 @@ exit 1
 
 		Expect(push).To(Exit(0))
 		appOutput := cf.Cf("app", appName).Wait()
-		Expect(appOutput).To(Say("buildpacks?:.*\\n.+\\n.*Simple"))
+		Expect(appOutput).To(Say("buildpacks?:.*\\n.+\\n.+\\n.*Simple"))
 	}
 
 	itDoesNotDetectForEmptyApp := func() {
@@ -344,7 +344,7 @@ exit 1
 			Expect(cf.Cf("push", appName, "-b", buildpackName, "-m", DEFAULT_MEMORY_LIMIT, "-p", appPath).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 			appOutput := cf.Cf("app", appName).Wait()
-			Expect(appOutput).To(Say("buildpacks?:.*\\n.+\\n.*" + buildpackName))
+			Expect(appOutput).To(Say("buildpacks?:.*\\n.+\\n.+\\n.*" + buildpackName))
 		})
 
 		It("fails if the specified buildpack is disabled", func() {


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

No. Against:
https://github.com/SUSE/cf-acceptance-tests



### What is this change about?

Fix failing tests due to failed comparison:

`• Failure [80.083 seconds]
[apps]
/var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers/cats_suite_helpers.go:32
  Admin Buildpacks
  /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers/cats_suite_helpers.go:38
    when the buildpack is specified
    /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry/cf-acceptance-tests/apps/admin_buildpack_lifecycle.go:340
      stages the app using the specified buildpack [It]
      /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry/cf-acceptance-tests/apps/admin_buildpack_lifecycle.go:341

      Got stuck at:
          Showing health and status for app CATS-2-APP-1a6b65ad544ac0ad in org CATS-2-ORG-7de1a35f1ac45a71 / space CATS-2-SPACE-517db5d34ff4cbac as CATS-2-USER-07ae0a3b4a844302...
          
          name:                CATS-2-APP-1a6b65ad544ac0ad
          requested state:     started
          isolation segment:   placeholder
          routes:              CATS-2-APP-1a6b65ad544ac0ad.kubecf-jvbuns-eirini-0-0-4.gcpenv.dev
          last uploaded:       Fri 18 Sep 09:17:37 UTC 2020
          stack:               sle15
          buildpacks:          
          isolation segment:   placeholder
          	name                          version   detect output   buildpack name
          	CATS-2-BPK-77187c0064ebcfaf                             
          
          type:           web
          sidecars:       
          instances:      1/1
          memory usage:   256M
               state     since                  cpu    memory      disk        details
          #0   running   2020-09-18T09:17:44Z   0.0%   0 of 256M   40K of 1G   
          
      Waiting for:
          buildpacks?:.*\n.+\n.*CATS-2-BPK-77187c0064ebcfaf

      /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry/cf-acceptance-tests/apps/admin_buildpack_lifecycle.go:347`

And:
`• Failure [87.070 seconds]
[apps]
/var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers/cats_suite_helpers.go:32
  Admin Buildpacks
  /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers/cats_suite_helpers.go:38
    when the buildpack is not specified
    /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry/cf-acceptance-tests/apps/admin_buildpack_lifecycle.go:320
      runs the app only if the buildpack is detected [It]
      /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry/cf-acceptance-tests/apps/admin_buildpack_lifecycle.go:321

      Got stuck at:
          Showing health and status for app CATS-4-APP-ba54996fdc2f5b81 in org CATS-4-ORG-36b18512acee3313 / space CATS-4-SPACE-47bec649d8f1e0ae as CATS-4-USER-2132454f053587c5...
          
          name:                CATS-4-APP-ba54996fdc2f5b81
          requested state:     started
          isolation segment:   placeholder
          routes:              CATS-4-APP-ba54996fdc2f5b81.kubecf-jvbuns-eirini-0-0-4.gcpenv.dev
          last uploaded:       Fri 18 Sep 09:18:45 UTC 2020
          stack:               sle15
          buildpacks:          
          isolation segment:   placeholder
          	name                          version   detect output   buildpack name
          	CATS-4-BPK-efcd694ce542073b             Simple          Simple
          
          type:           web
          sidecars:       
          instances:      1/1
          memory usage:   256M
               state     since                  cpu    memory      disk      details
          #0   running   2020-09-18T09:18:55Z   0.0%   0 of 256M   0 of 1G   
          
      Waiting for:
          buildpacks?:.*\n.+\n.*Simple

      /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry/cf-acceptance-tests/apps/admin_buildpack_lifecycle.go:274`

### Please provide contextual information.

This is an additional fix to this:
https://github.com/SUSE/cf-acceptance-tests/pull/3


### What version of cf-deployment have you run this cf-acceptance-test change against?

v13.9.0

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ x ] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [ x ] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A


### How should this change be described in cf-acceptance-tests release notes?

N/A



### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ x ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@jimmykarily @viccuad @viovanov 
