### PR TITLE
fix: Use nodejs buildpack that supports sle15 stack

### DIFF
--- a/internet_dependent/git_buildpack.go
+++ b/internet_dependent/git_buildpack.go
@@ -23,7 +23,7 @@ var _ = InternetDependentDescribe("GitBuildpack", func() {
 		Expect(cf.Cf("push", appName,
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Node,
-			"-b", "https://github.com/cloudfoundry/nodejs-buildpack.git#v1.7.24",
+			"-b", "https://github.com/SUSE/cf-nodejs-buildpack.git#v1.7.28.1",
 		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 		Eventually(func() string {


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?


No. Against:
https://github.com/SUSE/cf-acceptance-tests


### What is this change about?

Test:
```
  [internet_dependent] GitBuildpack [It] uses a buildpack from a git url                                                                                                                                                                                                      [176/586]
  /home/vic/suse/cf-acceptance-tests/internet_dependent/git_buildpack.go:27
```
Fails with `**ERROR** Unsupported stack`, as the nodejs buildpack doesn't
support the sle15 stack.

Use a SUSE one that supports it.


### Please provide contextual information.


### What version of cf-deployment have you run this cf-acceptance-test change against?

13.17 (kubecf 0.2.0-1926.ge5bcd109)

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._



### How should this change be described in cf-acceptance-tests release notes?

_Something brief that conveys the change and is written with the component author audience in mind._



### How many more (or fewer) seconds of runtime will this change introduce to CATs?

No change.


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
