### PR TITLE
fix: Update ssh/ssh.go tests for Eirini

### DIFF
--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -93,9 +93,10 @@ var _ = SshDescribe("SSH", func() {
 			// Newer Eirini has INSTANCE_INDEX fixed but until then, let's look for something that is there
 			Expect(string(output)).To(MatchRegexp("START_COMMAND=\\.\\/catnip"))
 
-			Eventually(func() *Buffer {
-				return logs.Recent(appName).Wait().Out
-			}).Should(Say("Successful remote access"))
+			// Eirini doesn't log ssh access
+			// Eventually(func() *Buffer {
+			// 	return logs.Recent(appName).Wait().Out
+			// }).Should(Say("Successful remote access"))
 			Eventually(func() string {
 				return string(cf.Cf("events", appName).Wait().Out.Contents())
 			}).Should(MatchRegexp("audit.app.ssh-authorized"))
@@ -135,9 +136,10 @@ var _ = SshDescribe("SSH", func() {
 			// Newer Eirini has INSTANCE_INDEX fixed but until then, let's look for something that is there
 			Expect(string(output)).To(MatchRegexp("START_COMMAND=\\.\\/catnip"))
 
-			Eventually(func() *Buffer {
-				return logs.Recent(appName).Wait().Out
-			}).Should(Say("Successful remote access"))
+			// Eirini doesn't log ssh access
+			// Eventually(func() *Buffer {
+			// 	return logs.Recent(appName).Wait().Out
+			// }).Should(Say("Successful remote access"))
 
 			Eventually(func() string {
 				return string(cf.Cf("events", appName).Wait().Out.Contents())
@@ -166,6 +168,9 @@ var _ = SshDescribe("SSH", func() {
 		})
 
 		It("records successful ssh attempts", func() {
+
+			Skip("Eirini doesn't log ssh access")
+
 			password := sshAccessCode()
 
 			clientConfig := &ssh.ClientConfig{

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -51,6 +51,8 @@ var _ = SshDescribe("SSH", func() {
 			})
 
 			It("can ssh to the second instance", func() {
+				Skip("Newer Eirini has INSTANCE_INDEX fixed but until then skip this test")
+
 				// sometimes ssh'ing to the second instance fails because the instance isn't running
 				// so we try a few times
 				Eventually(func() *Session {
@@ -64,10 +66,11 @@ var _ = SshDescribe("SSH", func() {
 				stdErr := string(envCmd.Err.Contents())
 
 				Expect(string(output)).To(MatchRegexp(fmt.Sprintf(`VCAP_APPLICATION=.*"application_name":"%s"`, appName)))
-				Expect(string(output)).To(MatchRegexp("INSTANCE_INDEX=1"))
+				// Newer Eirini has INSTANCE_INDEX fixed but until then, let's look for something that is there
+				Expect(string(stdErr)).To(MatchRegexp("START_COMMAND=\\.\\/catnip"))
 
-				Expect(string(stdErr)).To(MatchRegexp(fmt.Sprintf(`VCAP_APPLICATION=.*"application_name":"%s"`, appName)))
-				Expect(string(stdErr)).To(MatchRegexp("INSTANCE_INDEX=1"))
+				// Newer Eirini has INSTANCE_INDEX fixed but until then, let's look for something that is there
+				Expect(string(output)).To(MatchRegexp("START_COMMAND=\\.\\/catnip"))
 
 				Eventually(func() *Buffer {
 					return logs.Recent(appName).Wait().Out
@@ -86,11 +89,9 @@ var _ = SshDescribe("SSH", func() {
 			output := string(envCmd.Out.Contents())
 			stdErr := string(envCmd.Err.Contents())
 
-			Expect(string(output)).To(MatchRegexp(fmt.Sprintf(`VCAP_APPLICATION=.*"application_name":"%s"`, appName)))
-			Expect(string(output)).To(MatchRegexp("INSTANCE_INDEX=0"))
-
 			Expect(string(stdErr)).To(MatchRegexp(fmt.Sprintf(`VCAP_APPLICATION=.*"application_name":"%s"`, appName)))
-			Expect(string(stdErr)).To(MatchRegexp("INSTANCE_INDEX=0"))
+			// Newer Eirini has INSTANCE_INDEX fixed but until then, let's look for something that is there
+			Expect(string(output)).To(MatchRegexp("START_COMMAND=\\.\\/catnip"))
 
 			Eventually(func() *Buffer {
 				return logs.Recent(appName).Wait().Out
@@ -131,7 +132,8 @@ var _ = SshDescribe("SSH", func() {
 			Expect(exitErr).NotTo(HaveOccurred(), "Failed to run SSH command: %s, %s", output, errOutput)
 
 			Expect(string(output)).To(MatchRegexp(fmt.Sprintf(`VCAP_APPLICATION=.*"application_name":"%s"`, appName)))
-			Expect(string(output)).To(MatchRegexp("INSTANCE_INDEX=0"))
+			// Newer Eirini has INSTANCE_INDEX fixed but until then, let's look for something that is there
+			Expect(string(output)).To(MatchRegexp("START_COMMAND=\\.\\/catnip"))
 
 			Eventually(func() *Buffer {
 				return logs.Recent(appName).Wait().Out
@@ -182,7 +184,8 @@ var _ = SshDescribe("SSH", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(string(output)).To(MatchRegexp(fmt.Sprintf(`VCAP_APPLICATION=.*"application_name":"%s"`, appName)))
-			Expect(string(output)).To(MatchRegexp("INSTANCE_INDEX=0"))
+			// Newer Eirini has INSTANCE_INDEX fixed but until then, let's look for something that is there
+			Expect(string(output)).To(MatchRegexp("START_COMMAND=\\.\\/catnip"))
 
 			Eventually(func() *Buffer {
 				return logs.Recent(appName).Wait().Out


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

No. Against:
https://github.com/SUSE/cf-acceptance-tests


### What is this change about?

Fix the following ssh tests:
```
[Fail] [ssh] SSH ssh [It] runs an interactive session when no command is provided 
/home/vic/suse/cf-acceptance-tests/ssh/ssh.go:134

[Fail] [ssh] SSH ssh [It] can execute a remote command in the container 
/home/vic/suse/cf-acceptance-tests/ssh/ssh.go:90

[Fail] [ssh] SSH ssh with multiple instances [It] can ssh to the second instance 
/home/vic/suse/cf-acceptance-tests/ssh/ssh.go:67

[Fail] [ssh] SSH ssh [It] records successful ssh attempts 
/home/vic/suse/cf-acceptance-tests/ssh/ssh.go:185

[Fail] [ssh] SSH ssh [It] records successful ssh attempts 
/home/vic/suse/cf-acceptance-tests/ssh/ssh.go:185
```

- Use START_COMMAND env var instead of INSTANCE_INDEX=1 in ssh.go
  Newer eirini has INSTANCE_INDEX present in env, but until then:
  - Look for START_COMMAND as a different unique env var.
  - Skip "can ssh to the second instance"

- Don't check for "Successful remote access" in app logs on ssh.go
  Eirini doesn't write to logs when an ssh access happens, unlike Diego:
    https://github.com/cloudfoundry/diego-ssh/blob/4e330a244ce12b69a0ad2f89478e343208e3ea48/authenticators/permissions_builder.go#L52
  So, either:
  - Just don't check for that line in `cf logs`, as the test already checks that
    the ssh has happened.
  - Skip "records successful ssh attempts", as Eirini doesn't record them.

### Please provide contextual information.

This changes disable 2 tests for Diego, too.

### What version of cf-deployment have you run this cf-acceptance-test change against?

13.17 (kubecf 0.2.0-1926.ge5bcd109)

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?



### How should this change be described in cf-acceptance-tests release notes?



### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
