### PR TITLE
fix: Don't account for newlines in regexps for buildpack

### DIFF
--- a/apps/admin_buildpack_lifecycle.go
+++ b/apps/admin_buildpack_lifecycle.go
@@ -271,7 +271,7 @@ exit 1
 
 		Expect(push).To(Exit(0))
 		appOutput := cf.Cf("app", appName).Wait()
-		Expect(appOutput).To(Say("buildpacks?:.*\\n.+\\n.+\\n.*Simple"))
+		Expect(appOutput).To(Say("buildpacks?:.*Simple"))
 	}
 
 	itDoesNotDetectForEmptyApp := func() {
@@ -344,7 +344,7 @@ exit 1
 			Expect(cf.Cf("push", appName, "-b", buildpackName, "-m", DEFAULT_MEMORY_LIMIT, "-p", appPath).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 			appOutput := cf.Cf("app", appName).Wait()
-			Expect(appOutput).To(Say("buildpacks?:.*\\n.+\\n.+\\n.*" + buildpackName))
+			Expect(appOutput).To(Say("buildpacks?:.*" + buildpackName))
 		})
 
 		It("fails if the specified buildpack is disabled", func() {


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

No. Against:
https://github.com/SUSE/cf-acceptance-tests

### What is this change about?

Fixes the following app tests:
```
[Fail] [apps] Admin Buildpacks when the buildpack is not specified [It] runs the app only if the buildpack is detected                                                                                              
/home/vic/suse/cf-acceptance-tests/apps/admin_buildpack_lifecycle.go:274

[Fail] [apps] Admin Buildpacks when the buildpack is specified [It] stages the app using the specified buildpack                                                                                                    
/home/vic/suse/cf-acceptance-tests/apps/admin_buildpack_lifecycle.go:347
```



### Please provide contextual information.



### What version of cf-deployment have you run this cf-acceptance-test change against?

13.17 (kubecf 0.2.0-1926.ge5bcd109)

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

### How should this change be described in cf-acceptance-tests release notes?

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

No change.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
